### PR TITLE
Add tests

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,22 @@ jobs:
       uses: actions-rs/cargo@v1.0.1
       with:
         command: clippy
+
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: rust-toolchain
+      uses: actions-rs/toolchain@v1.0.3
+      with:
+        toolchain: stable
+        components: clippy
+
+    - name: install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+    - name: test
+      run: wasm-pack test --headless --chrome

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "wasm-bindgen-test",
  "worker",
 ]
 
@@ -790,6 +791,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1156,30 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasm-streams"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ reqwest = { version = "0.11", features = ["json", "blocking"] }
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.1", optional = true }
 
+[dev-dependencies]
+wasm-bindgen-test = "0.3.0"
+
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ fn log_request(req: &Request) {
 }
 
 #[derive(Deserialize)]
-struct Payload {
-    name: String,
-    email: String,
-    message: String,
+pub struct Payload {
+    pub name: String,
+    pub email: String,
+    pub message: String,
 }
 
 #[event(fetch, respond_with_errors)]

--- a/tests/send_message.rs
+++ b/tests/send_message.rs
@@ -1,0 +1,17 @@
+use mainmatter_website_mailer::{send_message, Payload};
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn it_works() {
+    //     let payload = Payload {
+    //         name: String::from("name"),
+    //         email: String::from("email@domain.tld"),
+    //         message: String::from("Hi!"),
+    //     };
+    //     let result = send_message(payload, "api_key").await;
+    //
+    //     assert_eq!(result.unwrap().status_code(), 200);
+    assert_eq!(1, 1);
+}

--- a/tests/send_message.rs
+++ b/tests/send_message.rs
@@ -1,17 +1,115 @@
-use mainmatter_website_mailer::{send_message, Payload};
+use mainmatter_website_mailer::{send_message, NetworkError, Payload};
+use serde_json::json;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
-async fn it_works() {
-    //     let payload = Payload {
-    //         name: String::from("name"),
-    //         email: String::from("email@domain.tld"),
-    //         message: String::from("Hi!"),
-    //     };
-    //     let result = send_message(payload, "api_key").await;
-    //
-    //     assert_eq!(result.unwrap().status_code(), 200);
-    assert_eq!(1, 1);
+async fn it_works_for_the_happy_path() {
+    async fn request_sendgrid(_api_key: &str, _data: String) -> Result<u16, NetworkError> {
+        Ok(202)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from("Hi!"),
+    };
+    let result = send_message(payload, "api_key", &request_sendgrid).await;
+
+    assert_eq!(result.unwrap().status_code(), 200);
+}
+
+#[wasm_bindgen_test]
+async fn it_sends_the_right_payload_to_sendgrid() {
+    async fn request_sendgrid(_api_key: &str, data: String) -> Result<u16, NetworkError> {
+        let expected = json!({
+            "personalizations": [{
+                "to": [
+                    { "email": "contact@mainmatter.com", "name": "Mainmatter" }
+                ]}
+            ],
+            "from": { "email": "no-reply@mainmatter.com", "name": "name via mainmatter.com" },
+            "reply_to": { "email": "email@domain.tld", "name": "name" },
+            "subject": "Mainmatter inquiry",
+            "content": [{
+                "type": "text/plain",
+                "value": "Hi!"
+            }]
+        });
+
+        assert_eq!(data, expected.to_string());
+
+        Ok(200)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from("Hi!"),
+    };
+    let _result = send_message(payload, "api_key", &request_sendgrid).await;
+}
+
+#[wasm_bindgen_test]
+async fn it_sends_an_empty_message_if_none_is_provided() {
+    async fn request_sendgrid(_api_key: &str, data: String) -> Result<u16, NetworkError> {
+        let expected = json!({
+            "personalizations": [{
+                "to": [
+                    { "email": "contact@mainmatter.com", "name": "Mainmatter" }
+                ]}
+            ],
+            "from": { "email": "no-reply@mainmatter.com", "name": "name via mainmatter.com" },
+            "reply_to": { "email": "email@domain.tld", "name": "name" },
+            "subject": "Mainmatter inquiry",
+            "content": [{
+                "type": "text/plain",
+                "value": "–"
+            }]
+        });
+
+        assert_eq!(data, expected.to_string());
+
+        Ok(200)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from(""),
+    };
+    let _result = send_message(payload, "api_key", &request_sendgrid).await;
+}
+
+#[wasm_bindgen_test]
+async fn it_responds_with_502_if_sendgrid_errors() {
+    async fn request_sendgrid(_api_key: &str, _data: String) -> Result<u16, NetworkError> {
+        Ok(500)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from("Hi!"),
+    };
+    let result = send_message(payload, "api_key", &request_sendgrid).await;
+
+    assert_eq!(result.unwrap().status_code(), 502);
+}
+
+#[wasm_bindgen_test]
+async fn it_responds_with_500_if_calling_sendgrid_errors() {
+    async fn request_sendgrid(_api_key: &str, _data: String) -> Result<u16, NetworkError> {
+        Err(NetworkError)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from("Hi!"),
+    };
+    let result = send_message(payload, "api_key", &request_sendgrid).await;
+
+    assert_eq!(result.unwrap().status_code(), 500);
 }


### PR DESCRIPTION
This adds tests.

## TODO

- [x] The tests can only be meaningful if we can mock the response from Sendgrid. The standard ways of mocking responses in Rust don't work in WASM though – I presume we'll need to find something that works in WASM or build some kind of abstraction that is swappable in tests (see https://github.com/rustwasm/wasm-pack/issues/1178)…