### PR TITLE
include selected service in message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub struct Payload {
     pub name: String,
     pub email: String,
     pub message: String,
+    pub service: String,
 }
 
 #[event(fetch, respond_with_errors)]
@@ -64,6 +65,8 @@ where
 {
     let message = payload.message.trim();
     let message = if !message.is_empty() { message } else { "–" };
+    let service = payload.service.trim();
+    let service = if !service.is_empty() { service } else { "–" };
 
     let data = json!({
         "personalizations": [{
@@ -76,7 +79,7 @@ where
         "subject": "Mainmatter inquiry",
         "content": [{
             "type": "text/plain",
-            "value": message
+            "value": format!("Service: {service}\n\n{message}")
         }]
     });
 

--- a/tests/send_message.rs
+++ b/tests/send_message.rs
@@ -14,6 +14,7 @@ async fn it_works_for_the_happy_path() {
         name: String::from("name"),
         email: String::from("email@domain.tld"),
         message: String::from("Hi!"),
+        service: String::from("Digital Products & Design"),
     };
     let result = send_message(payload, "api_key", &request_sendgrid).await;
 
@@ -34,7 +35,7 @@ async fn it_sends_the_right_payload_to_sendgrid() {
             "subject": "Mainmatter inquiry",
             "content": [{
                 "type": "text/plain",
-                "value": "Hi!"
+                "value": "Service: Digital Products & Design\n\nHi!"
             }]
         });
 
@@ -47,6 +48,7 @@ async fn it_sends_the_right_payload_to_sendgrid() {
         name: String::from("name"),
         email: String::from("email@domain.tld"),
         message: String::from("Hi!"),
+        service: String::from("Digital Products & Design"),
     };
     let _result = send_message(payload, "api_key", &request_sendgrid).await;
 }
@@ -65,7 +67,7 @@ async fn it_sends_an_empty_message_if_none_is_provided() {
             "subject": "Mainmatter inquiry",
             "content": [{
                 "type": "text/plain",
-                "value": "–"
+                "value": "Service: Digital Products & Design\n\n–"
             }]
         });
 
@@ -78,6 +80,39 @@ async fn it_sends_an_empty_message_if_none_is_provided() {
         name: String::from("name"),
         email: String::from("email@domain.tld"),
         message: String::from(""),
+        service: String::from("Digital Products & Design"),
+    };
+    let _result = send_message(payload, "api_key", &request_sendgrid).await;
+}
+
+#[wasm_bindgen_test]
+async fn it_sends_an_empty_service_if_none_is_provided() {
+    async fn request_sendgrid(_api_key: &str, data: String) -> Result<u16, NetworkError> {
+        let expected = json!({
+            "personalizations": [{
+                "to": [
+                    { "email": "contact@mainmatter.com", "name": "Mainmatter" }
+                ]}
+            ],
+            "from": { "email": "no-reply@mainmatter.com", "name": "name via mainmatter.com" },
+            "reply_to": { "email": "email@domain.tld", "name": "name" },
+            "subject": "Mainmatter inquiry",
+            "content": [{
+                "type": "text/plain",
+                "value": "Service: –\n\nHi!"
+            }]
+        });
+
+        assert_eq!(data, expected.to_string());
+
+        Ok(200)
+    }
+
+    let payload = Payload {
+        name: String::from("name"),
+        email: String::from("email@domain.tld"),
+        message: String::from("Hi!"),
+        service: String::from(""),
     };
     let _result = send_message(payload, "api_key", &request_sendgrid).await;
 }
@@ -92,6 +127,7 @@ async fn it_responds_with_502_if_sendgrid_errors() {
         name: String::from("name"),
         email: String::from("email@domain.tld"),
         message: String::from("Hi!"),
+        service: String::from(""),
     };
     let result = send_message(payload, "api_key", &request_sendgrid).await;
 
@@ -108,6 +144,7 @@ async fn it_responds_with_500_if_calling_sendgrid_errors() {
         name: String::from("name"),
         email: String::from("email@domain.tld"),
         message: String::from("Hi!"),
+        service: String::from(""),
     };
     let result = send_message(payload, "api_key", &request_sendgrid).await;
 


### PR DESCRIPTION
This includes the selected service from the form on the website:

<img width="641" alt="Bildschirm­foto 2023-03-17 um 11 37 51" src="https://user-images.githubusercontent.com/1510/225881843-eb6c8a4d-f047-48c8-bdce-029475ddb06c.png">

in the delivered email:

```
Service: Digital Products & Design

Hi!
```